### PR TITLE
Initializting buffer value to 0 before setting bits

### DIFF
--- a/src/modbuspal/link/ModbusTcpIpSlaveDispatcher.java
+++ b/src/modbuspal/link/ModbusTcpIpSlaveDispatcher.java
@@ -155,7 +155,7 @@ implements Runnable
                     ModbusTools.setUint16(buffer,4,pduLength+1);
 
                     // send all
-                    slaveOutput.write(buffer,0, 7+pduLength);
+                    slaveOutput.write(buffer, 0, 7 + pduLength);
                     slaveOutput.flush();
                 }
             }

--- a/src/modbuspal/slave/ModbusCoils.java
+++ b/src/modbuspal/slave/ModbusCoils.java
@@ -283,6 +283,9 @@ extends ModbusRegisters
         for(int i=0; i<quantity; i++)
         {
             Integer reg = getValue(startingAddress+i);
+            if (i%8 == 0) {
+                buffer[offset + i/8] = 0;
+            }
             ModbusTools.setBit(buffer, (offset*8)+i, reg);
         }
         return XC_SUCCESSFUL;


### PR DESCRIPTION
It seems buffer is not getting fully cleared after incoming messages or responses, which is fine, however when reading multiple coils we need to make sure the bytes we send back only contain data for that particular request